### PR TITLE
Move postinstall-build from dev to dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "babel-watch": "^2.0.5",
-    "postinstall-build": "^3.0.1"
+    "babel-watch": "^2.0.5"
   },
   "dependencies": {
     "babel-regenerator-runtime": "^6.5.0",
@@ -60,6 +59,7 @@
     "instagram-private-api": "^0.5.16",
     "json2csv": "^3.7.3",
     "ora": "^1.2.0",
-    "portscanner": "^2.1.1"
+    "portscanner": "^2.1.1",
+    "postinstall-build": "^3.0.1"
   }
 }


### PR DESCRIPTION
Cannot install package without postinstall-build


When installing I get 


```
$ npm i -G instastat
npm WARN deprecated fs-promise@2.0.3: Use mz or fs-extra^3.0 with Promise Support
npm WARN prefer global json2csv@3.8.0 should be installed with -g
npm WARN prefer global instastat@2.0.0 should be installed with -g

> instastat@2.0.0 postinstall /Users/james/personal/insta-node/node_modules/instastat
> postinstall-build build "npm run build"

sh: postinstall-build: command not found
npm ERR! Darwin 16.6.0
npm ERR! argv "/usr/local/Cellar/node/6.8.1/bin/node" "/usr/local/bin/npm" "i" "-G" "instastat"
npm ERR! node v6.8.1
npm ERR! npm  v3.10.8
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn

npm ERR! instastat@2.0.0 postinstall: `postinstall-build build "npm run build"`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the instastat@2.0.0 postinstall script 'postinstall-build build "npm run build"'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the instastat package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     postinstall-build build "npm run build"
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs instastat
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls instastat
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/james/personal/insta-node/npm-debug.log
```

Moving to dependancies solves the issue